### PR TITLE
Format & rendering links

### DIFF
--- a/v0.1/index.md
+++ b/v0.1/index.md
@@ -341,5 +341,9 @@ Link_ID    |  Object_ID
 ![Gap_Split_C](images/Gap+Split_C.png){:class="img-responsive"}
 
 
-### Links
-See the data package representation of this specification.
+## File formats
+
+See this [repository](https://github.com/CellMigStandOrg/cell_track_dpkg) for
+more information about a
+[Data Package](http://frictionlessdata.io/data-packages/) based file format
+which supports this specification.

--- a/v0.1/index.md
+++ b/v0.1/index.md
@@ -284,7 +284,7 @@ The **links table** can take one of the following forms:
 
 - **A**
 
-Link_ID |  Object_ID
+Link_ID    |  Object_ID
 -----------|------------
  1         |    1
  1         |    2
@@ -295,11 +295,12 @@ Link_ID |  Object_ID
  2         |    4
  2         |    6
  2         |    8
+
 ![Gap_Split_A](images/Gap+Split_A.png){:class="img-responsive"}
 
 - **B**
 
-Link_ID |  Object_ID
+Link_ID    |  Object_ID
 -----------|------------
  1         |    1
  1         |    2
@@ -310,12 +311,13 @@ Link_ID |  Object_ID
  2         |    4
  2         |    6
  2         |    8
+
 ![Gap_Split_B](images/Gap+Split_B.png){:class="img-responsive"}
 
  - **C**
 
 
- Link_ID |  Object_ID
+ Link_ID   |  Object_ID
 -----------|------------
  1         |    1
  1         |    2
@@ -327,6 +329,7 @@ Link_ID |  Object_ID
  4	       |    4
  4	       |    6
  4	       |    8
+
 ![Gap_Split_C](images/Gap+Split_C.png){:class="img-responsive"}
 
 

--- a/v0.1/index.md
+++ b/v0.1/index.md
@@ -38,7 +38,9 @@ Object_ID  |  Frame  |  X |  Y
 8          |    3    |    |
 9          |    3    |    |
 
-With a linking algorithm, an association is created between objects across frames, and links are produced. The colored lines in the next figure represent these links.
+With a linking algorithm, an association is created between objects across
+frames, and links are produced. The colored lines in the next figure represent
+these links.
 
 ![links](images/SimpleTrack_Links.png){:class="img-responsive"}
 
@@ -58,7 +60,8 @@ The **links table** is:
 
 In this table, the foreign key to the objects table is the **Object_ID**.
 This specification requires unique **Object_ID** in the objects table. If this
-is not the case, an extra **frame** column `MUST` be present in the links table.
+is not the case, an extra **frame** column `MUST` be present in the links
+table.
 
 Finally, tracks are derived from objects + links information:
 ![tracks](images/SimpleTrack_Tracks.png){:class="img-responsive"}
@@ -91,7 +94,9 @@ Object_ID  |  Frame  |  X |  Y
 3          |    4    |    |
 4          |    5    |    |
 
-In this specification, the gap-closing event is explicitly represented in the repetition of the **Object_ID** reference. Therefore, the **links table** can take one of the three following forms:
+In this specification, the gap-closing event is explicitly represented in the
+repetition of the **Object_ID** reference. Therefore, the **links table** can
+take one of the three following forms:
 
 - **A**
 
@@ -103,7 +108,8 @@ Link_ID |  Object_ID
  2         |    3
  2         |    4
 
-Here, the **Object_ID** repeated is the one after the gap event, and the **tracks table** is:
+Here, the **Object_ID** repeated is the one after the gap event, and the
+**tracks table** is:
 
 
   Track_ID |  Link_ID
@@ -125,7 +131,8 @@ Link_ID |  Object_ID
  2         |    3
  2         |    4
 
-Here, the **Object_ID** repeated is the one before the gap event, and the **tracks table** is:
+Here, the **Object_ID** repeated is the one before the gap event, and the
+**tracks table** is:
 
 
 Track_ID |  Link_ID
@@ -149,7 +156,8 @@ Link_ID |  Object_ID
  3         |    2
  3         |    3
 
-Here, both the **Object_ID** reference of the objects before and after the event are repeated, and the corresponding **tracks table** is:
+Here, both the **Object_ID** reference of the objects before and after the
+event are repeated, and the corresponding **tracks table** is:
 
  Track_ID |  Link_ID
  ---------|------------


### PR DESCRIPTION
Fixes #7 

- adds a reference to the https://github.com/CellMigStandOrg/cell_track_dpkg repository for the file format supporting this specification
- fixes some rendering issues noted on the live GH pages
- wraps some lines